### PR TITLE
:rocket: list objects by last modified

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,16 @@ def text_file(tmpdir_factory):
     tmp_file = tmpdir_factory.mktemp("tmp").join("temp_text_file.txt")
     tmp_file.write_text("botree test!", encoding="utf-8")
     return Path(tmp_file)
+
+
+@pytest.fixture(scope="session")
+def list_of_files(tmpdir_factory):
+    """Create a dummie list of files for s3 list objects by date."""
+    tmp_file = tmpdir_factory.mktemp("tmp").join("temp_text_file_1.txt")
+    tmp_file2 = tmpdir_factory.mktemp("tmp").join("temp_text_file_2.txt")
+    tmp_file3 = tmpdir_factory.mktemp("tmp").join("temp_text_file_3.txt")
+
+    for file in [tmp_file, tmp_file2, tmp_file3]:
+        file.write_text("botree test!", encoding="utf-8")
+
+    return [Path(tmp_file), Path(tmp_file2), Path(tmp_file3)]

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import time
 
 import pytest
 
@@ -36,6 +37,26 @@ def test_listobj_upload_download_delete(botree_session, botree_test_bucket, text
 
         with pytest.raises(KeyError):
             files = botree_session.s3.bucket(botree_test_bucket).list_objects()
+
+def test_list_obj_by_date(botree_session, botree_test_bucket, list_of_files):
+    """List objects by date method."""
+    with mock_s3():
+        botree_session.s3.create_bucket(botree_test_bucket)
+
+        ascending_order = [file.name for file in list_of_files]
+        descending_order = ascending_order[::-1]
+
+        for file in list_of_files:
+            botree_session.s3.bucket(botree_test_bucket).upload(file, file.name)
+            time.sleep(1)
+
+        files = botree_session.s3.bucket(botree_test_bucket).list_objects(sort_by_date="ascending")
+
+        assert files == ascending_order
+
+        files = botree_session.s3.bucket(botree_test_bucket).list_objects(sort_by_date="descending")
+
+        assert files == descending_order
 
 
 def test_copy_object(botree_session, botree_test_bucket, text_file):


### PR DESCRIPTION
Added `sort_by_date` parameter with optional `ascending` or `descending` values on `s3.list_objects()` method so users can order s3 objects by last/first modified